### PR TITLE
[FEAT/#3] 유저 인증 및 Supabase 인증 시스템 구현, 유저 프로필 및 알림 등 설정 관련 api 구성

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+from .auth_router import router as auth_router
+
+router = APIRouter(prefix="/auth")
+
+router.include_router(auth_router)
+
+
+from .auth_router import get_current_user
+
+__all__ = [
+    "router", 
+    "get_current_user",
+]

--- a/auth/auth_router.py
+++ b/auth/auth_router.py
@@ -1,0 +1,116 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+# import httpx
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import HTTPException
+# from fastapi.requests import Request
+from fastapi.security.oauth2 import OAuth2PasswordBearer
+from jose import jwt, JWTError
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from common.memcache.database import memcache_client
+from common.postgres.database import get_session
+from users.user import User
+from users.user_crud import user_crud
+
+from .dto import LoginReqDto
+
+router = APIRouter(tags=["Auth API"])
+
+
+SUPABASE_PROJECT_ID = os.getenv("SUPABASE_PROJECT_ID")
+SUPABASE_JWKS_URL = f"https://{SUPABASE_PROJECT_ID}.supabase.co/auth/v1/.well-known/jwks.json"
+SUPABASE_AUDIENCE = f"https://{SUPABASE_PROJECT_ID}.supabase.co/auth/v1"
+
+SERVER_JWT_SECRET = os.getenv("SERVER_JWT_SECRET")
+SERVER_JWT_ALGORITHM = "HS256"
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+# 서버 JWT 발급
+def create_server_jwt(user_id: str, email: str):
+    payload = {
+        "sub": user_id,
+        "email": email,
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1)
+    }
+    token = jwt.encode(payload, SERVER_JWT_SECRET, algorithm=SERVER_JWT_ALGORITHM)
+    return token
+
+async def get_current_user(token: str = Depends(oauth2_scheme)):
+    try:
+        payload = jwt.decode(token, SERVER_JWT_SECRET, algorithms=["HS256"])
+        if user := memcache_client.get(str(payload["sub"])):
+            return user
+        else:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+# Supabase JWT 검증
+async def verify_supabase_jwt(token: str):
+    # async with httpx.AsyncClient() as client:
+    #     jwks_response = await client.get(SUPABASE_JWKS_URL)
+    #     jwks = jwks_response.json()["keys"]
+
+    # for key in jwks:
+    #     try:
+    #         public_key = jwt.construct_rsa_public_key(key)
+    #         payload = jwt.decode(token, public_key, algorithms=["RS256"], audience=SUPABASE_AUDIENCE)
+    #         return payload  # 검증 성공
+    #     except JWTError:
+    #         continue
+
+    # 서버에서 직접 시크릿 키로 Supabase JWT를 해제(검증)하는 로직
+    try:
+        # 환경 변수에서 Supabase JWT 시크릿 키를 가져옴
+        supabase_jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
+        if not supabase_jwt_secret:
+            raise HTTPException(status_code=500, detail="Supabase JWT 시크릿이 설정되지 않았습니다.")
+
+        # JWT를 직접 해독 및 검증 (audience 포함)
+        payload = jwt.decode(
+            token,
+            supabase_jwt_secret,
+            algorithms=["HS256"],
+            audience="authenticated"
+        )
+        return payload  # 검증 성공 시 payload 반환
+    except JWTError:
+        # JWT 해독 실패 시 예외 처리
+        raise HTTPException(status_code=401, detail=f"Invalid token")
+
+    # raise HTTPException(status_code=401, detail="Invalid Supabase token")
+
+@router.post("/login")
+async def login(login_req: LoginReqDto, db: Session = Depends(get_session)):
+    supabase_token = login_req.access_token
+    if not supabase_token:
+        raise HTTPException(status_code=400, detail="Missing access_token")
+
+    payload = await verify_supabase_jwt(supabase_token)
+    openid = payload["sub"]
+    platform = payload["app_metadata"]["provider"]
+    email = payload.get("email")
+
+    # 서버 JWT 발급
+    flag = False
+    if not (user := user_crud.get_by_oauth(db, platform, openid)):
+        user = user_crud.create_user(db, User(platform=platform, openid=openid))
+        flag = True
+
+    server_jwt = create_server_jwt(user.user_id, email)
+    memcache_client.set(str(user.user_id), user, expire=60*60)
+    if flag:
+        # 회원가입 처리
+        return JSONResponse(status_code=201, content={"access_token": server_jwt})
+    else:
+        return JSONResponse(status_code=200, content={"access_token": server_jwt})
+
+@router.delete("/logout")
+async def logout(user: User = Depends(get_current_user)):
+    memcache_client.delete(str(user.user_id))
+    return {"message": "Logout"}

--- a/auth/dto/__init__.py
+++ b/auth/dto/__init__.py
@@ -1,0 +1,3 @@
+from .login_req import LoginReqDto
+
+__all__ = ["LoginReqDto"]

--- a/auth/dto/login_req.py
+++ b/auth/dto/login_req.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class LoginReqDto(BaseModel):
+    """로그인 요청 DTO"""
+    access_token: str

--- a/common/memcache/__init__.py
+++ b/common/memcache/__init__.py
@@ -1,0 +1,3 @@
+from .database import memcache_client
+
+__all__ = ["memcache_client"]

--- a/common/memcache/database.py
+++ b/common/memcache/database.py
@@ -1,0 +1,3 @@
+from pymemcache.client import Client
+
+memcache_client = Client(('localhost', 11211))

--- a/common/postgres/database.py
+++ b/common/postgres/database.py
@@ -26,18 +26,24 @@ engine = create_engine(
     pool_recycle=300,  # 5분마다 연결 재생성
 )
 
-# 세션 팩토리 생성
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-def create_db_and_tables():
-    """데이터베이스와 테이블 생성"""
-    SQLModel.metadata.create_all(engine)
-
-
+# 세션 팩토리 생성 (sqlmodel.Session을 직접 사용)
 def get_session() -> Generator[Session, None, None]:
-    """데이터베이스 세션 생성기"""
-    with SessionLocal() as session:
+    """
+    데이터베이스 세션 생성기
+
+    sqlmodel.Session을 반환하며, 예외 발생 시 롤백 처리 및 세션 종료를 보장합니다.
+
+    Yields:
+        Session: SQLModel 세션 객체
+
+    Raises:
+        Exception: 세션 내에서 발생한 예외를 다시 발생시킴
+
+    예시:
+        with next(get_session()) as session:
+            # 쿼리 실행
+    """
+    with Session(engine) as session:
         try:
             yield session
         except Exception:
@@ -45,6 +51,11 @@ def get_session() -> Generator[Session, None, None]:
             raise
         finally:
             session.close()
+
+
+def create_db_and_tables():
+    """데이터베이스와 테이블 생성"""
+    SQLModel.metadata.create_all(engine)
 
 
 # 데이터베이스 초기화 함수

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "httpx>=0.28.1",
     "psycopg2-binary>=2.9.10",
     "pydantic>=2.11.7",
+    "pymemcache>=4.0.0",
+    "python-jose>=3.5.0",
     "sqlmodel>=0.0.24",
+    "ulid>=1.1",
     "uvicorn>=0.35.0",
 ]

--- a/users/caregivers/caregiver.py
+++ b/users/caregivers/caregiver.py
@@ -4,6 +4,7 @@
 보호자 정보와 위치 캐시를 관리하는 모델
 """
 
+from typing import Optional
 from sqlmodel import Field, Relationship
 
 from common.postgres.models import TimestampMixin
@@ -17,5 +18,11 @@ class Caregiver(TimestampMixin, table=True):
     target_id: int = Field(foreign_key="users.user_id", description="보호 대상 ID")
 
     # 관계
-    user: "User" = Relationship(back_populates="caregivers")
-    target_user: "User" = Relationship(back_populates="target_caregivers")
+    user: Optional["User"] = Relationship(
+        back_populates="caregivers",
+        sa_relationship_kwargs={"foreign_keys": "[Caregiver.user_id]"}
+    )
+    target_user: Optional["User"] = Relationship(
+        back_populates="target_caregivers",
+        sa_relationship_kwargs={"foreign_keys": "[Caregiver.target_id]"}
+    )

--- a/users/caregivers/caregiver_crud.py
+++ b/users/caregivers/caregiver_crud.py
@@ -13,6 +13,31 @@ class CRUDCaregiver(CRUDBase[Caregiver, None, None]):
         """사용자 ID로 보호자 목록 조회"""
         statement = select(Caregiver).where(Caregiver.user_id == user_id)
         return db.exec(statement).all()
-
+    
+    def get_by_target_id(self, db: Session, target_id: int) -> List[Caregiver]:
+        """대상 ID로 보호자 목록 조회"""
+        statement = select(Caregiver).where(Caregiver.target_id == target_id)
+        return db.exec(statement).all()
+    
+    def create_caregiver_relationship(self, db: Session, user_id: int, target_id: int) -> Caregiver:
+        """보호자 관계 생성"""
+        caregiver = Caregiver(user_id=user_id, target_id=target_id)
+        db.add(caregiver)
+        db.commit()
+        db.refresh(caregiver)
+        return caregiver
+    
+    def delete_caregiver_relationship(self, db: Session, user_id: int, target_id: int) -> bool:
+        """보호자 관계 삭제"""
+        statement = select(Caregiver).where(
+            Caregiver.user_id == user_id,
+            Caregiver.target_id == target_id
+        )
+        caregiver = db.exec(statement).first()
+        if caregiver:
+            db.delete(caregiver)
+            db.commit()
+            return True
+        return False
 
 caregiver_crud = CRUDCaregiver(Caregiver)

--- a/users/dto/user_alert_update_res.py
+++ b/users/dto/user_alert_update_res.py
@@ -1,0 +1,7 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class UserAlertUpdateRes(BaseModel):
+    fcm_token: Optional[str] = None
+    is_alert: bool

--- a/users/dto/user_profile_alert_res.py
+++ b/users/dto/user_profile_alert_res.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class UserProfileAlertRes(BaseModel):
+    user_name: str
+    phone: str
+    is_caregiver: bool
+    is_helper: bool
+    fcm_token: Optional[str] = None
+    is_alert: bool

--- a/users/dto/user_profile_get_res.py
+++ b/users/dto/user_profile_get_res.py
@@ -1,0 +1,10 @@
+
+
+from pydantic import BaseModel
+
+
+class UserProfileGetRes(BaseModel):
+    user_name: str
+    phone: str
+    is_caregiver: bool
+    is_helper: bool

--- a/users/dto/user_profile_update_req.py
+++ b/users/dto/user_profile_update_req.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class UserProfileUpdateReq(BaseModel):
+    user_name: str
+    phone: str
+    is_caregiver: bool
+    is_helper: bool

--- a/users/dto/user_profile_update_res.py
+++ b/users/dto/user_profile_update_res.py
@@ -1,0 +1,10 @@
+
+
+from pydantic import BaseModel
+
+
+class UserProfileUpdateRes(BaseModel):
+    user_name: str
+    phone: str
+    is_caregiver: bool
+    is_helper: bool

--- a/users/user.py
+++ b/users/user.py
@@ -4,12 +4,12 @@
 사용자 정보, 프로필, 알림 설정을 관리하는 모델
 """
 
-import uuid
+from ulid import ulid
 from typing import Optional, Dict, Any
 from sqlalchemy import Column
-from sqlalchemy.dialects.postgresql import UUID, ENUM
+from sqlalchemy.dialects.postgresql import ENUM
 
-from sqlmodel import Field, Relationship
+from sqlmodel import Field, Relationship, String
 
 from common.postgres.models.base import TimestampMixin, OAuthPlatform
 
@@ -19,9 +19,9 @@ class User(TimestampMixin, table=True):
     __tablename__ = "users"
     
     user_id: Optional[int] = Field(default=None, primary_key=True, description="유저 구분 ID, jwt 토큰 부여 시 사용")
-    user_uuid: uuid.UUID = Field(
-        default_factory=uuid.uuid4, 
-        sa_column=Column(UUID(as_uuid=True), unique=True, index=True),
+    user_ulid: str = Field(
+        default_factory=lambda: str(ulid()), 
+        sa_column=Column(String(26), unique=True, index=True),
         description="유저 UUID, 유저 구분 시 사용"
     )
     
@@ -39,8 +39,14 @@ class User(TimestampMixin, table=True):
     alert: Optional["UserAlert"] = Relationship(back_populates="user", sa_relationship_kwargs={"uselist": False})
     favorites: list["LocationFavorite"] = Relationship(back_populates="user")
     route_histories: list["RouteHistory"] = Relationship(back_populates="user")
-    caregivers: list["Caregiver"] = Relationship(back_populates="user")
-    target_caregivers: list["Caregiver"] = Relationship(back_populates="target_user")
+    caregivers: list["Caregiver"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={"foreign_keys": "[Caregiver.user_id]"}
+    )
+    target_caregivers: list["Caregiver"] = Relationship(
+        back_populates="target_user",
+        sa_relationship_kwargs={"foreign_keys": "[Caregiver.target_id]"}
+    )
     safety_areas: list["SafetyArea"] = Relationship(back_populates="user")
 
 

--- a/users/user_crud.py
+++ b/users/user_crud.py
@@ -4,15 +4,13 @@
 사용자 정보, 프로필, 알림 설정에 대한 CRUD 작업
 """
 
-from typing import Optional, List
+from typing import Optional
 from sqlmodel import Session, select
 from sqlalchemy.orm import joinedload
 
 from common.postgres.crud.base import CRUDBase
 from .user import User, UserProfile, UserAlert
-from .caregivers.caregiver import Caregiver
-from .safety_area import SafetyArea
-from common.postgres.crud.base import OAuthPlatform
+from common.postgres.models import OAuthPlatform
 
 
 class CRUDUser(CRUDBase[User, None, None]):
@@ -90,42 +88,6 @@ class CRUDUserAlert(CRUDBase[UserAlert, None, None]):
             db.commit()
             db.refresh(alert)
         return alert
-
-
-class CRUDCaregiver(CRUDBase[Caregiver, None, None]):
-    """보호자 CRUD 작업"""
-    
-    def get_by_user_id(self, db: Session, user_id: int) -> List[Caregiver]:
-        """사용자 ID로 보호자 목록 조회"""
-        statement = select(Caregiver).where(Caregiver.user_id == user_id)
-        return db.exec(statement).all()
-    
-    def get_by_target_id(self, db: Session, target_id: int) -> List[Caregiver]:
-        """대상 ID로 보호자 목록 조회"""
-        statement = select(Caregiver).where(Caregiver.target_id == target_id)
-        return db.exec(statement).all()
-    
-    def create_caregiver_relationship(self, db: Session, user_id: int, target_id: int) -> Caregiver:
-        """보호자 관계 생성"""
-        caregiver = Caregiver(user_id=user_id, target_id=target_id)
-        db.add(caregiver)
-        db.commit()
-        db.refresh(caregiver)
-        return caregiver
-    
-    def delete_caregiver_relationship(self, db: Session, user_id: int, target_id: int) -> bool:
-        """보호자 관계 삭제"""
-        statement = select(Caregiver).where(
-            Caregiver.user_id == user_id,
-            Caregiver.target_id == target_id
-        )
-        caregiver = db.exec(statement).first()
-        if caregiver:
-            db.delete(caregiver)
-            db.commit()
-            return True
-        return False
-
 
 # CRUD 인스턴스 생성
 user_crud = CRUDUser(User)

--- a/users/user_crud.py
+++ b/users/user_crud.py
@@ -9,13 +9,18 @@ from sqlmodel import Session, select
 from sqlalchemy.orm import joinedload
 
 from common.postgres.crud.base import CRUDBase
+from users.dto.user_profile_update_req import UserProfileUpdateReq
 from .user import User, UserProfile, UserAlert
 from common.postgres.models import OAuthPlatform
 
 
 class CRUDUser(CRUDBase[User, None, None]):
     """사용자 CRUD 작업"""
-    
+    def get_by_user_id(self, db: Session, user_id: int) -> Optional[User]:
+        """사용자 ID로 사용자 조회"""
+        statement = select(User).where(User.user_id == user_id)
+        return db.exec(statement).first()
+
     def get_by_uuid(self, db: Session, user_uuid: str) -> Optional[User]:
         """UUID로 사용자 조회"""
         statement = select(User).where(User.user_uuid == user_uuid)
@@ -38,6 +43,34 @@ class CRUDUser(CRUDBase[User, None, None]):
         """알림 설정과 함께 사용자 조회"""
         statement = select(User).options(joinedload(User.alert)).where(User.user_id == user_id)
         return db.exec(statement).first()
+    
+    def get_with_profile_and_alert(self, db: Session, user_id: int) -> Optional[User]:
+        """모든 정보와 함께 사용자 조회"""
+        statement = select(User.profile, User.alert).where(User.user_id == user_id)
+        return db.exec(statement).first()
+    
+    def create_user(self, db: Session, user: User) -> User:
+        """사용자 생성"""        
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    def delete_user(self, db: Session, user_id: int) -> bool:
+        """사용자 삭제"""
+        user = self.get_by_user_id(db, user_id)
+        if user:
+            user_profile = user_profile_crud.get_by_user_id(db, user_id)
+            user_alert = user_alert_crud.get_by_user_id(db, user_id)
+            if user_profile:
+                db.delete(user_profile)
+            if user_alert:
+                db.delete(user_alert)
+            db.delete(user)
+            db.commit()
+            return True
+        else:
+            return False
 
 
 class CRUDUserProfile(CRUDBase[UserProfile, None, None]):
@@ -48,17 +81,32 @@ class CRUDUserProfile(CRUDBase[UserProfile, None, None]):
         statement = select(UserProfile).where(UserProfile.user_id == user_id)
         return db.exec(statement).first()
     
-    def update_by_user_id(self, db: Session, user_id: int, user_name: str, phone: str, is_caregiver: bool = False) -> Optional[UserProfile]:
+    def create_user_profile(self, db: Session, user_profile: UserProfile) -> Optional[UserProfile]:
+        """사용자 프로필 생성"""
+        user_profile = UserProfile(user_id=user_profile.user_id, user_name=user_profile.user_name, phone=user_profile.phone, is_caregiver=user_profile.is_caregiver)
+        db.add(user_profile)
+        db.commit()
+        db.refresh(user_profile)
+        return user_profile
+
+    def update_by_user_id(self, db: Session, user_id: int, user_profile: UserProfileUpdateReq) -> Optional[UserProfile]:
         """사용자 ID로 프로필 업데이트"""
         profile = self.get_by_user_id(db, user_id)
         if profile:
-            profile.user_name = user_name
-            profile.phone = phone
-            profile.is_caregiver = is_caregiver
+            if user_profile.user_name:
+                profile.user_name = user_profile.user_name
+            if user_profile.phone:
+                profile.phone = user_profile.phone
+            if user_profile.is_caregiver is not None:
+                profile.is_caregiver = user_profile.is_caregiver
+            if user_profile.is_helper is not None:
+                profile.is_helper = user_profile.is_helper
             db.add(profile)
             db.commit()
             db.refresh(profile)
-        return profile
+            return profile
+        else:
+            raise ValueError(f"UserProfile with user_id {user_id} not found")
 
 
 class CRUDUserAlert(CRUDBase[UserAlert, None, None]):
@@ -69,6 +117,14 @@ class CRUDUserAlert(CRUDBase[UserAlert, None, None]):
         statement = select(UserAlert).where(UserAlert.user_id == user_id)
         return db.exec(statement).first()
     
+    def create_user_alert(self, db: Session, user_alert: UserAlert) -> Optional[UserAlert]:
+        """사용자 알림 설정 생성"""
+        user_alert = UserAlert(user_id=user_alert.user_id, is_alert=user_alert.is_alert)
+        db.add(user_alert)
+        db.commit()
+        db.refresh(user_alert)
+        return user_alert
+
     def update_fcm_token(self, db: Session, user_id: int, fcm_token: str) -> Optional[UserAlert]:
         """FCM 토큰 업데이트"""
         alert = self.get_by_user_id(db, user_id)
@@ -77,17 +133,21 @@ class CRUDUserAlert(CRUDBase[UserAlert, None, None]):
             db.add(alert)
             db.commit()
             db.refresh(alert)
-        return alert
+            return alert
+        else:
+            raise ValueError(f"UserAlert with user_id {user_id} not found")
     
-    def toggle_alert(self, db: Session, user_id: int) -> Optional[UserAlert]:
+    def update_alert_flag(self, db: Session, user_id: int, is_alert: bool) -> Optional[UserAlert]:
         """알림 설정 토글"""
         alert = self.get_by_user_id(db, user_id)
         if alert:
-            alert.is_alert = not alert.is_alert
+            alert.is_alert = is_alert
             db.add(alert)
             db.commit()
             db.refresh(alert)
-        return alert
+            return alert
+        else:
+            raise ValueError(f"UserAlert with user_id {user_id} not found")
 
 # CRUD 인스턴스 생성
 user_crud = CRUDUser(User)

--- a/users/user_router.py
+++ b/users/user_router.py
@@ -1,0 +1,207 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from auth import get_current_user
+from common.memcache.database import memcache_client
+from common.postgres.database import get_session
+from users.dto.user_alert_update_res import UserAlertUpdateRes
+from users.dto.user_profile_alert_res import UserProfileAlertRes
+from users.dto.user_profile_update_req import UserProfileUpdateReq
+from users.dto.user_profile_update_res import UserProfileUpdateRes
+from users.user_crud import user_alert_crud, user_crud, user_profile_crud
+
+from .user import User
+
+
+router = APIRouter(tags=["User API"])
+
+
+@router.get(
+    "/me",
+    response_model=UserProfileAlertRes,
+    responses={
+        200: {
+            "description": "User profile and alert fetched",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "user_name": "John Doe", 
+                        "phone": "1234567890", 
+                        "is_caregiver": True, 
+                        "is_helper": False,
+                        "fcm_token": "fcm_token", 
+                        "is_alert": True}
+                }
+            }
+        },
+        401: {
+            "description": "Unauthorized",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Unauthorized"}
+                }
+            }
+        }
+    }
+)
+async def get_user(
+    user: User = Depends(get_current_user), 
+    db: Session = Depends(get_session)
+):
+    user_profile, user_alert = user_crud.get_with_profile_and_alert(db, user.user_id)
+    return JSONResponse(
+        status_code=200, 
+        content=UserProfileAlertRes(
+            user_name=user_profile.user_name, 
+            phone=user_profile.phone, 
+            is_caregiver=user_profile.is_caregiver, 
+            is_helper=user_profile.is_helper,
+            fcm_token=user_alert.fcm_token, 
+            is_alert=user_alert.is_alert
+        )
+    )
+
+
+@router.put(
+    "/me/profile",
+    response_model=UserProfileUpdateRes,
+    responses={
+        200: {
+            "description": "User profile updated",
+            "content": {
+                "application/json": {
+                    "example": {"user_name": "John Doe", "phone": "1234567890", "is_caregiver": True, "is_helper": False}
+                }
+            }
+        },
+        401: {
+            "description": "Unauthorized",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Unauthorized"}
+                }
+            }
+        }
+    }
+)
+async def update_user_profile(
+    user_profile: UserProfileUpdateReq, 
+    user: User = Depends(get_current_user), 
+    db: Session = Depends(get_session)
+):
+    user_profile = user_profile_crud.update_by_user_id(db, user.user_id, user_profile)
+    return JSONResponse(
+        status_code=200, 
+        content=UserProfileUpdateRes(
+            user_name=user_profile.user_name, 
+            phone=user_profile.phone, 
+            is_caregiver=user_profile.is_caregiver, 
+            is_helper=user_profile.is_helper
+        )
+    )
+
+
+@router.put(
+    "/me/alert/fcm-token",
+    response_model=UserAlertUpdateRes,
+    responses={
+        200: {
+            "description": "User alert fcm token updated",
+            "content": {
+                "application/json": {
+                    "example": {"fcm_token": "fcm_token", "is_alert": True}
+                }
+            }
+        },
+        401: {
+            "description": "Unauthorized",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Unauthorized"}
+                }
+            }
+        }
+    }
+)
+async def update_user_alert_fcm_token(
+    fcm_token: str,
+    user: User = Depends(get_current_user), 
+    db: Session = Depends(get_session)
+):
+    user_alert = user_alert_crud.update_fcm_token(db, user.user_id, fcm_token)
+    return JSONResponse(
+        status_code=200, 
+        content=UserAlertUpdateRes(
+            fcm_token=user_alert.fcm_token, 
+            is_alert=user_alert.is_alert
+        )
+    )
+
+
+@router.put(
+    "/me/alert/flag",
+    response_model=UserAlertUpdateRes,
+    responses={
+        200: {
+            "description": "User alert flag updated",
+            "content": {
+                "application/json": {
+                    "example": {"fcm_token": "fcm_token", "is_alert": True}
+                }
+            }
+        },
+        401: {
+            "description": "Unauthorized",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Unauthorized"}
+                }
+            }
+        }
+    }
+)
+async def update_user_alert(
+    is_alert: bool,
+    user: User = Depends(get_current_user), 
+    db: Session = Depends(get_session)
+):
+    user_alert = user_alert_crud.update_alert_flag(db, user.user_id, is_alert)
+    return JSONResponse(
+        status_code=200, 
+        content=UserAlertUpdateRes(
+            fcm_token=user_alert.fcm_token, 
+            is_alert=user_alert.is_alert
+        )
+    )
+
+
+@router.delete(
+    "/me",
+    responses={
+        200: {
+            "description": "User deleted",
+            "content": {
+                "application/json": {
+                    "example": {"message": "User deleted"}
+                }
+            }
+        },
+        401: {
+            "description": "Unauthorized",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Unauthorized"}
+                }
+            }
+        }
+    }
+)
+async def delete_user(user: User = Depends(get_current_user), db: Session = Depends(get_session)):
+    user_crud.delete_user(db, user.user_id)
+    memcache_client.delete(str(user.user_id))
+    return JSONResponse(
+        status_code=200, 
+        content={"message": "User deleted"}
+    )
+

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,10 @@ dependencies = [
     { name = "httpx" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pymemcache" },
+    { name = "python-jose" },
     { name = "sqlmodel" },
+    { name = "ulid" },
     { name = "uvicorn" },
 ]
 
@@ -48,7 +51,10 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pymemcache", specifier = ">=4.0.0" },
+    { name = "python-jose", specifier = ">=3.5.0" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
+    { name = "ulid", specifier = ">=1.1" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
@@ -91,6 +97,18 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
 ]
 
 [[package]]
@@ -240,6 +258,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -297,12 +324,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pymemcache"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/b6/4541b664aeaad025dfb8e851dcddf8e25ab22607e674dd2b562ea3e3586f/pymemcache-4.0.0.tar.gz", hash = "sha256:27bf9bd1bbc1e20f83633208620d56de50f14185055e49504f4f5e94e94aff94", size = 70176, upload-time = "2022-10-17T16:53:07.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/ba/2f7b22d8135b51c4fefb041461f8431e1908778e6539ff5af6eeaaee367a/pymemcache-4.0.0-py2.py3-none-any.whl", hash = "sha256:f507bc20e0dc8d562f8df9d872107a278df049fa496805c1431b926f3ddd0eab", size = 60772, upload-time = "2022-10-17T16:53:04.388Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -389,6 +460,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
 ]
+
+[[package]]
+name = "ulid"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/d4/6829692e4902d53684b7696cf3d5158f07439ebc4bc3ca7822b5ca173e44/ulid-1.1.tar.gz", hash = "sha256:0943e8a751ec10dfcdb4df2758f96dffbbfbc055d0b49288caf2f92125900d49", size = 1174, upload-time = "2016-08-01T23:00:12.792Z" }
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
## 연관 이슈
- #3 

<!--
자세한 개발 내용을 PR title로 달아주세요
    ex) [FEAT#issue번호]: 어쩌구저쩌
!-->

<br>

## 구현 내용
<!--
PR이 포함한 변경사항과 관련 중요한 스크립트나 오브젝트를 명시해주세요
   ex) 스크립트/함수: 어쩌구저쩌
!-->
- Supabase 인증 시스템 구현
  - Supabase는 JWT 토큰을 통한 인증을 진행하고, 실질적인 인증은 별도로 부여하는 서버 자체 JWT로 진행
  - JWT는 user_id와 그 외로 구성되어 있으며 변경 가능, 현재 3600초를 기한으로 설정
  - memcached를 도입하여 현재 인증 중인 유저를 등록(3600초)해두었다가 로그아웃 혹은 타임 아웃 후 소거
  
- 프로필 변경 api
  - 현재 프로필은 이름, 연락처, 보호자 여부, 도우미 여부만 필드로 두고 있음, 이후 추가 예정
  
- 알림 상태 변경 api
  - fcm 토큰 갱신 api 구성
  - 알림 여부 설정 api 구성

<br>

## TODO
<!--
보완해야 할 사항을 적어주세요
!-->
- 프로필 필드 추가

<br>

## 논의 사항
<!--
개발이나 기획 관련 논의가 필요한 사항을 적어주세요
!-->
- 

<br>
